### PR TITLE
Add LMA link to Charmhub discourse navigation

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -39,6 +39,9 @@
               <a href="https://juju.is/docs/sdk" class="p-subnav__item">Charmed Operator SDK</a>
             </li>
             <li>
+              <a href="https://juju.is/docs/lma2" class="p-subnav__item">Logs, Metrics and Alerts (LMA) 2</a>
+            </li>
+            <li>
               <a href="https://juju.is/tutorials" class="p-subnav__item">Tutorials</a>
             </li>
           </ul>


### PR DESCRIPTION
For consistency with juju.is and charmhub.io